### PR TITLE
Normalize vector extension tag casing

### DIFF
--- a/normative_rule_defs/v-st-ext.yaml
+++ b/normative_rule_defs/v-st-ext.yaml
@@ -7,10 +7,10 @@ $schema: "../docs-resources/schemas/defs-schema.json#"
 
 normative_rule_definitions:
   - name: ELEN_param
-    tags: ["norm:ELEN_param"]
+    tags: ["norm:elen_param"]
 
   - name: VLEN_param
-    tags: ["norm:VLEN_param"]
+    tags: ["norm:vlen_param"]
 
   - name: vill_implicit_encoding_param
     tags: ["norm:vill_implicit_encoding_param"]
@@ -76,34 +76,34 @@ normative_rule_definitions:
     tags: ["norm:vtype-vsew_rsv"]
 
   - name: vtype-lmul_val
-    tags: ["norm:vtype-LMUL_val"]
+    tags: ["norm:vtype-lmul_val"]
 
   - name: vtype-lmul_fval
-    tags: ["norm:vtype-LMUL_fval"]
+    tags: ["norm:vtype-lmul_fval"]
 
   - name: vtype-sew_val
-    tags: ["norm:vtype-SEW_val"]
+    tags: ["norm:vtype-sew_val"]
 
   - name: vtype-lmul_fval_rsv
-    tags: ["norm:vtype-LMUL_fval_rsv"]
+    tags: ["norm:vtype-lmul_fval_rsv"]
 
   - name: LMUL
-    tags: ["norm:LMUL"]
+    tags: ["norm:lmul"]
 
   - name: VLMAX
-    tags: ["norm:VLMAX"]
+    tags: ["norm:vlmax"]
 
   - name: vreg_offgroup_LMUL2_rsv
-    tags: ["norm:vreg_offgroup_LMUL2_rsv"]
+    tags: ["norm:vreg_offgroup_lmul2_rsv"]
 
   - name: vreg_offgroup_LMUL4_rsv
-    tags: ["norm:vreg_offgroup_LMUL4_rsv"]
+    tags: ["norm:vreg_offgroup_lmul4_rsv"]
 
   - name: vreg_offgroup_LMUL8_rsv
-    tags: ["norm:vreg_offgroup_LMUL8_rsv"]
+    tags: ["norm:vreg_offgroup_lmul8_rsv"]
 
   - name: vreg_mask_LMUL_indp
-    tags: ["norm:vreg_mask_LMUL_indp"]
+    tags: ["norm:vreg_mask_lmul_indp"]
 
   - name: vtype-vta_op
     tags: ["norm:vtype-vta-vma_op"]
@@ -178,13 +178,13 @@ normative_rule_definitions:
     tags: ["norm:vcsr-vxrm-vxsat_acc"]
 
   - name: vreg_lmul1_op
-    tags: ["norm:vreg_LMUL1_op"]
+    tags: ["norm:vreg_lmul1_op"]
 
   - name: vreg_flmul_op
-    tags: ["norm:vreg_fLMUL_op"]
+    tags: ["norm:vreg_flmul_op"]
 
   - name: vreg_lmulge2_op
-    tags: ["norm:vreg_LMULge2_op"]
+    tags: ["norm:vreg_lmulge2_op"]
 
   - name: vreg_mask_vtype_indp
     tags: ["norm:vreg_mask_vtype_indp"]
@@ -193,31 +193,31 @@ normative_rule_definitions:
     tags: ["norm:vreg_mask_sz"]
 
   - name: vreg_scalar_lmul_indp
-    tags: ["norm:vreg_scalar_LMUL_indp"]
+    tags: ["norm:vreg_scalar_lmul_indp"]
 
   - name: EEW
-    tags: ["norm:EEW_EMUL"]
+    tags: ["norm:eew_emul"]
 
   - name: EMUL
-    tags: ["norm:EEW_EMUL"]
+    tags: ["norm:eew_emul"]
 
   - name: EMUL_SEW_LMUL_dep
-    tags: ["norm:EEW_EMUL_SEW_LMUL_dep"]
+    tags: ["norm:eew_emul_sew_lmul_dep"]
 
   - name: EEW_SEW_LMUL_dep
-    tags: ["norm:EEW_EMUL_SEW_LMUL_dep"]
+    tags: ["norm:eew_emul_sew_lmul_dep"]
 
   - name: vnarrowing_EEW
-    tags: ["norm:vnarrowing_EEW_EMUL"]
+    tags: ["norm:vnarrowing_eew_emul"]
 
   - name: vnarrowing_EMUL
-    tags: ["norm:vnarrowing_EEW_EMUL"]
+    tags: ["norm:vnarrowing_eew_emul"]
 
   - name: EMUL_offgroup_rsv
-    tags: ["norm:EMUL_offgroup_rsv"]
+    tags: ["norm:emul_offgroup_rsv"]
 
   - name: vreg_source_EEW_rsv
-    tags: ["norm:vreg_source_EEW_rsv"]
+    tags: ["norm:vreg_source_eew_rsv"]
 
   - name: vreg_overlap_legal
     tags: ["norm:vreg_overlap_legal"]
@@ -232,10 +232,10 @@ normative_rule_definitions:
     tags: ["norm:vreg_overlap_agn"]
 
   - name: EMUL_rsv
-    tags: ["norm:EMUL_rsv"]
+    tags: ["norm:emul_rsv"]
 
   - name: vreg_scalar_EMUL
-    tags: ["norm:vreg_scalar_EMUL"]
+    tags: ["norm:vreg_scalar_emul"]
 
   - name: vmask_op
     tags: ["norm:vmask_inactive_op", "norm:vmask_agn_op", "norm:vmask_vm_enc"]
@@ -301,7 +301,7 @@ normative_rule_definitions:
     tags: ["norm:vector_ls_constant-stride_op"]
 
   - name: vector_ls_strided_EEW
-    tags: ["norm:vector_ls_strided_EEW"]
+    tags: ["norm:vector_ls_strided_eew"]
 
   - name: vector_ls_seg_unit-stride_vd_vs3
     tags: ["norm:vector_ls_seg_unit-stride_vd_vs3"]
@@ -322,7 +322,7 @@ normative_rule_definitions:
     tags: ["norm:vector_ls_indexed_op"]
   
   - name: vector_ls_indexed_EEW
-    tags: ["norm:vector_ls_indexed_EEW"]
+    tags: ["norm:vector_ls_indexed_eew"]
 
   - name: vector_ls_ins_req
     tags: ["norm:vector_ls_ins_req"]
@@ -334,10 +334,10 @@ normative_rule_definitions:
     tags: ["norm:vector_ls_bytewise"]
 
   - name: vector_ls_XLEN_dep
-    tags: ["norm:vector_ls_XLEN_dep"]
+    tags: ["norm:vector_ls_xlen_dep"]
 
   - name: vector_ls_EEW_rsv
-    tags: ["norm:vector_ls_EEW_rsv"]
+    tags: ["norm:vector_ls_eew_rsv"]
 
   - name: vector_ls_stride_ordered_op
     tags: ["norm:vector_ls_stride_ordered_op"]
@@ -355,22 +355,22 @@ normative_rule_definitions:
     tags: ["norm:vector_wholels_nf_op"]
 
   - name: vector_ls_EEW
-    tags: ["norm:vector_ls_EEW_EMUL"]
+    tags: ["norm:vector_ls_eew_emul"]
 
   - name: vector_ls_EMUL
-    tags: ["norm:vector_ls_EEW_EMUL"]
+    tags: ["norm:vector_ls_eew_emul"]
 
   - name: vector_ls_EMUL_rsv
-    tags: ["norm:vector_ls_EMUL_rsv"]
+    tags: ["norm:vector_ls_emul_rsv"]
 
   - name: vector_ls_EMUL_offgroup_rsv
-    tags: ["norm:vector_ls_EMUL_offgroup_rsv"]
+    tags: ["norm:vector_ls_emul_offgroup_rsv"]
 
   - name: vector_ls_indexed_EEW
-    tags: ["norm:vector_ls_indexed_EEW_EMUL"]
+    tags: ["norm:vector_ls_indexed_eew_emul"]
 
   - name: vector_ls_indexed_EMUL
-    tags: ["norm:vector_ls_indexed_EEW_EMUL"]
+    tags: ["norm:vector_ls_indexed_eew_emul"]
 
   - name: vector_ls_ins_rsv
     tags: ["norm:vector_ls_ins_rsv"]
@@ -409,10 +409,10 @@ normative_rule_definitions:
     tags: ["norm:vector_ff_interrupt_behavior"]
 
   - name: NFIELDS
-    tags: ["norm:NFIELDS", "norm:NFIELDS_op"]
+    tags: ["norm:nfields", "norm:nfields_op"]
 
   - name: EMUL_NFIELDS_rsv
-    tags: ["norm:EMUL_NFIELDS_rsv"]
+    tags: ["norm:emul_nfields_rsv"]
 
   - name: vector_ls_seg_rsv
     tags: ["norm:vector_ls_seg_rsv"]
@@ -427,7 +427,7 @@ normative_rule_definitions:
     tags: ["norm:vector_ls_seg_vstart_dep"]
 
   - name: VECTOR_LS_SEG_PARTIAL_ACCESS
-    tags: ["norm:VECTOR_LS_SEG_PARTIAL_ACCESS"]
+    tags: ["norm:vector_ls_seg_partial_access"]
 
   - name: vector_ls_seg_unit-stride_op
     tags: ["norm:vector_ls_seg_unit-stride_op"]
@@ -436,10 +436,10 @@ normative_rule_definitions:
     tags: ["norm:vector_ls__seg_ff_unit-stride_op"]
 
   - name: VECTOR_FF_SEG_PARTIAL_ACCESS
-    tags: ["norm:VECTOR_FF_SEG_PARTIAL_ACCESS"]
+    tags: ["norm:vector_ff_seg_partial_access"]
 
   - name: vector_ls_seg_ff_overload
-    tags: ["norm:VECTOR_LS_SEG_FF_OVERLOAD"]
+    tags: ["norm:vector_ls_seg_ff_overload"]
 
   - name: vector_ls_seg_constant-stride_op
     tags: ["norm:vector_ls_seg_constant-stride_op"]
@@ -451,19 +451,19 @@ normative_rule_definitions:
     tags: ["norm:vector_ls_seg_indexed_op"]
 
   - name: vector_ls_seg_indexed_EMUL_op
-    tags: ["norm:vector_ls_seg_indexed_EEW_EMUL_op"]
+    tags: ["norm:vector_ls_seg_indexed_eew_emul_op"]
 
   - name: vector_ls_seg_indexed_EEW_op
-    tags: ["norm:vector_ls_seg_indexed_EEW_EMUL_op"]
+    tags: ["norm:vector_ls_seg_indexed_eew_emul_op"]
 
   - name: vector_ls_seg_indexed_EMUL_NFIELDS_val
-    tags: ["norm:vector_ls_seg_indexed_EMUL_NFIELDS_val"]
+    tags: ["norm:vector_ls_seg_indexed_emul_nfields_val"]
 
   - name: vector_ls_seg_indexed_vreg_rsv
     tags: ["norm:vector_ls_seg_indexed_vreg_rsv"]
 
   - name: vector_ls_seg_wholereg_EEW
-    tags: ["norm:vector_ls_seg_wholereg_EEW"]
+    tags: ["norm:vector_ls_seg_wholereg_eew"]
 
   - name: vector_ls_seg_wholereg_op
     tags: ["norm:vector_ls_seg_wholereg_op"]
@@ -487,13 +487,13 @@ normative_rule_definitions:
     tags: ["norm:vector_ls_program_order"]
 
   - name: vector_ls_RVWMO
-    tags: ["norm:vector_ls_RVWMO"]
+    tags: ["norm:vector_ls_rvwmo"]
 
   - name: vector_ls_indexed-ordered_ordered
     tags: ["norm:vector_ls_indexed-ordered_ordered"]
 
   - name: vector_ls_indexed-ordered_RVWMO
-    tags: ["norm:vector_ls_indexed-ordered_RVWMO"]
+    tags: ["norm:vector_ls_indexed-ordered_rvwmo"]
 
   - name: vl_control_dependency
     tags: ["norm:vl_control_dependency"]

--- a/src/v-st-ext.adoc
+++ b/src/v-st-ext.adoc
@@ -23,9 +23,9 @@ supported by each extension.
 
 Each hart supporting a vector extension defines two parameters:
 
-. [#norm:ELEN_param]#The maximum size in bits of a vector element that any operation can produce or consume, _ELEN_ {ge} 8, which
+. [#norm:elen_param]#The maximum size in bits of a vector element that any operation can produce or consume, _ELEN_ {ge} 8, which
 must be a power of 2.#
-. [#norm:VLEN_param]#The number of bits in a single vector register, _VLEN_ {ge} ELEN, which must be a power of 2, and must be no greater than 2^16^.#
+. [#norm:vlen_param]#The number of bits in a single vector register, _VLEN_ {ge} ELEN, which must be a power of 2, and must be no greater than 2^16^.#
 
 Standard vector extensions (<<sec-vector-extensions>>) and
 architecture profiles may set further constraints on _ELEN_ and _VLEN_.
@@ -134,7 +134,7 @@ illegal-instruction exception when either field is set to Off.
 [#norm:vsstatus-vs_mstatus-vs_op_active]#When V=1 and neither `vsstatus.VS` nor `mstatus.VS` is set to Off, executing
 any instruction that changes vector state, including the vector CSRs, will
 change both `mstatus.VS` and `vsstatus.VS` to Dirty.#
-[#norm:HW_MSTATUS_VS_DIRTY_UPDATE]#Implementations may also change `mstatus.VS` or `vsstatus.VS` from Initial or
+[#norm:hw_mstatus_vs_dirty_update]#Implementations may also change `mstatus.VS` or `vsstatus.VS` from Initial or
 Clean to Dirty at any time, even when there is no change in vector state.#
 
 [[norm:vsstatus-sd_op_vs]]
@@ -249,7 +249,7 @@ their inclusion is to allow double-width or larger elements to be
 operated on with the same vector length as single-width elements.  The
 vector length multiplier, _LMUL_, when greater than 1, represents the
 default number of vector registers that are combined to form a vector
-register group.  [#norm:vtype-LMUL_val]#Implementations must support LMUL integer values of
+register group.  [#norm:vtype-lmul_val]#Implementations must support LMUL integer values of
 1, 2, 4, and 8.#
 
 
@@ -280,7 +280,7 @@ vector registers are unused, but in some cases, having more shorter
 register-resident vectors improves efficiency relative to fewer longer
 register-resident vectors.
 
-[[norm:vtype-LMUL_fval]]
+[[norm:vtype-lmul_fval]]
 Implementations must provide fractional LMUL settings that allow the
 narrowest supported type to occupy a fraction of a vector register
 corresponding to the ratio of the narrowest supported type's width to
@@ -299,11 +299,11 @@ valid implementation choice. For example, with VLEN=ELEN=32,
 and SEW~MIN~=8, an LMUL of 1/8 would only provide four bits of
 storage in a vector register.
 
-[[norm:vtype-SEW_val]]
+[[norm:vtype-sew_val]]
 For a given supported fractional LMUL setting, implementations must support
 SEW settings between SEW~MIN~ and LMUL * ELEN, inclusive.
 
-[[norm:vtype-LMUL_fval_rsv]]
+[[norm:vtype-lmul_fval_rsv]]
 The use of `vtype` encodings with LMUL < SEW~MIN~/ELEN is
 __reserved__, but implementations can set `vill` if they do not
 support these configurations.
@@ -316,11 +316,11 @@ consider the use of this case to be __reserved__.
 NOTE: It is recommended that assemblers provide a warning (not an
 error) if a `vsetvli` instruction attempts to write an LMUL < SEW~MIN~/ELEN.
 
-[[norm:LMUL]]
+[[norm:lmul]]
 LMUL is set by the signed `vlmul` field in `vtype` (i.e., LMUL =
 2^`vlmul[2:0]`^).
 
-[[norm:VLMAX]]
+[[norm:vlmax]]
 The derived value VLMAX = LMUL*VLEN/SEW represents the maximum number
 of elements that can be operated on with a single vector instruction
 given the current SEW and LMUL settings as shown in the table below.
@@ -342,18 +342,18 @@ given the current SEW and LMUL settings as shown in the table below.
 
 When LMUL=2, the vector register group contains vector register `v`
 __n__ and vector register `v` __n__+1, providing twice the vector
-length in bits.  [#norm:vreg_offgroup_LMUL2_rsv]#Instructions specifying an LMUL=2 vector register group
+length in bits.  [#norm:vreg_offgroup_lmul2_rsv]#Instructions specifying an LMUL=2 vector register group
 with an odd-numbered vector register are reserved.#
 
 When LMUL=4, the vector register group contains four vector registers,
-and [#norm:vreg_offgroup_LMUL4_rsv]#instructions specifying an LMUL=4 vector register group using vector
+and [#norm:vreg_offgroup_lmul4_rsv]#instructions specifying an LMUL=4 vector register group using vector
 register numbers that are not multiples of four are reserved.#
 
 When LMUL=8, the vector register group contains eight vector
-registers, and [#norm:vreg_offgroup_LMUL8_rsv]#instructions specifying an LMUL=8 vector register group
+registers, and [#norm:vreg_offgroup_lmul8_rsv]#instructions specifying an LMUL=8 vector register group
 using register numbers that are not multiples of eight are reserved.#
 
-[[norm:vreg_mask_LMUL_indp]]
+[[norm:vreg_mask_lmul_indp]]
 Mask registers are always contained in a single vector register,
 regardless of LMUL.
 
@@ -701,7 +701,7 @@ different EEW.
 
 ==== Mapping for LMUL = 1
 
-[[norm:vreg_LMUL1_op]]
+[[norm:vreg_lmul1_op]]
 When LMUL=1, elements are simply packed in order from the
 least-significant to most-significant bits of the vector register.
 
@@ -756,7 +756,7 @@ least-significant byte of the stored element.
 
 ==== Mapping for LMUL < 1
 
-[[norm:vreg_fLMUL_op]]
+[[norm:vreg_flmul_op]]
 When LMUL < 1, only the first LMUL*VLEN/SEW elements in the vector
 register are used.  The remaining space in the vector register is
 treated as part of the tail, and hence must obey the vta setting.
@@ -773,7 +773,7 @@ treated as part of the tail, and hence must obey the vta setting.
 
 ==== Mapping for LMUL > 1
 
-[[norm:vreg_LMULge2_op]]
+[[norm:vreg_lmulge2_op]]
 When vector registers are grouped, the elements of the vector register
 group are packed contiguously in element order beginning with the
 lowest-numbered vector register and moving to the
@@ -937,7 +937,7 @@ held in vector register elements.
 Scalar operands can be immediates, or taken from the `x` registers,
 the `f` registers, or element 0 of a vector register.  Scalar results
 are written to an `x` or `f` register or to element 0 of a vector
-register.  [#norm:vreg_scalar_LMUL_indp]#Any vector register can be used to hold a scalar regardless
+register.  [#norm:vreg_scalar_lmul_indp]#Any vector register can be used to hold a scalar regardless
 of the current LMUL setting.#
 
 NOTE: Zfinx ("F in X") is a new ISA extension where
@@ -958,7 +958,7 @@ would prevent compatibility with the Zfinx ISA option.
 [[sec-vec-operands]]
 ==== Vector Operands
 
-[[norm:EEW_EMUL]]
+[[norm:eew_emul]]
 Each vector operand has an _effective_ _element_ _width_ (EEW) and an
 _effective_ LMUL (EMUL) that is used to determine the size and
 location of all the elements within a vector register group.  By
@@ -967,19 +967,19 @@ EMUL=LMUL.
 
 Some vector instructions have source and destination vector operands
 with the same number of elements but different widths, so that EEW and
-EMUL differ from SEW and LMUL respectively but [#norm:EEW_EMUL_SEW_LMUL_dep]#EEW/EMUL = SEW/LMUL.#
+EMUL differ from SEW and LMUL respectively but [#norm:eew_emul_sew_lmul_dep]#EEW/EMUL = SEW/LMUL.#
 For example, most widening arithmetic instructions have a source group
 with EEW=SEW and EMUL=LMUL but have a destination group with EEW=2*SEW and
-EMUL=2*LMUL.  [#norm:vnarrowing_EEW_EMUL]#Narrowing instructions have a source operand that has
+EMUL=2*LMUL.  [#norm:vnarrowing_eew_emul]#Narrowing instructions have a source operand that has
 EEW=2*SEW and EMUL=2*LMUL but with a destination where EEW=SEW and EMUL=LMUL.#
 
 Vector operands or results may occupy one or more vector registers
 depending on EMUL, but are always specified using the lowest-numbered
-vector register in the group.  [#norm:EMUL_offgroup_rsv]#Using other than the lowest-numbered
+vector register in the group.  [#norm:emul_offgroup_rsv]#Using other than the lowest-numbered
 vector register to specify a vector register group is a reserved
 encoding.#
 
-[[norm:vreg_source_EEW_rsv]]
+[[norm:vreg_source_eew_rsv]]
 A vector register cannot be used to provide source operands with more
 than one EEW for a single instruction.  A mask register source is
 considered to have EEW=1 for this constraint.  An encoding that would
@@ -1025,7 +1025,7 @@ When source and destination registers overlap and have different EEW, the
 instruction is mask- and tail-agnostic, regardless of the setting of the
 `vta` and `vma` bits in `vtype`.
 
-[[norm:EMUL_rsv]]
+[[norm:emul_rsv]]
 The largest vector register group used by an instruction can not be
 greater than 8 vector registers (i.e., EMUL{le}8), and if a vector
 instruction would require greater than 8 vector registers in a group,
@@ -1033,7 +1033,7 @@ the instruction encoding is reserved.  For example, a widening
 operation that produces a widened vector register group result when
 LMUL=8 is reserved as this would imply a result EMUL=16.
 
-[[norm:vreg_scalar_EMUL]]
+[[norm:vreg_scalar_emul]]
 Widened scalar values, e.g., input and output to a widening reduction
 operation, are held in the first element of a vector register and
 have EMUL=1.
@@ -1410,7 +1410,7 @@ include::images/wavedrom/vmem-format.edn[]
 | lumop[4:0]/sumop[4:0] | are additional fields encoding variants of unit-stride instructions
 |===
 
-[#norm:vector_ls_strided_EEW]#Vector memory unit-stride and constant-stride operations directly encode EEW of the data to be transferred statically in the instruction to reduce the number of `vtype` changes when accessing memory in a mixed-width routine.# [#norm:vector_ls_indexed_EEW]#Indexed operations use the explicit EEW encoding in the instruction to set the size of the indices used, and use SEW/LMUL to specify the data width.#
+[#norm:vector_ls_strided_eew]#Vector memory unit-stride and constant-stride operations directly encode EEW of the data to be transferred statically in the instruction to reduce the number of `vtype` changes when accessing memory in a mixed-width routine.# [#norm:vector_ls_indexed_eew]#Indexed operations use the explicit EEW encoding in the instruction to set the size of the indices used, and use SEW/LMUL to specify the data width.#
 
 ==== Vector Load/Store Addressing Modes
 
@@ -1451,12 +1451,12 @@ member field in each object.  Supporting this case is why the indexed
 operations were not defined to scale the element indices by the data
 EEW.
 
-[[norm:vector_ls_XLEN_dep]]
+[[norm:vector_ls_xlen_dep]]
 If the vector offset elements are narrower than XLEN, they are
 zero-extended to XLEN before adding to the base effective address.  If
 the vector offset elements are wider than XLEN, the least-significant
 XLEN bits are used in the address calculation.
-[[norm:vector_ls_EEW_rsv]]
+[[norm:vector_ls_eew_rsv]]
 If the implementation does not support the EEW of the offset elements,
 the instruction is reserved.
 
@@ -1549,14 +1549,14 @@ to transfer for the whole vector register load/store instructions.
 [[sec-vector-loadstore-width-encoding]]
 ==== Vector Load/Store Width Encoding
 
-[#norm:vector_ls_EEW_EMUL]#Vector loads and stores have an EEW encoded directly in the
+[#norm:vector_ls_eew_emul]#Vector loads and stores have an EEW encoded directly in the
 instruction.  The corresponding EMUL is calculated as EMUL =
-(EEW/SEW)*LMUL.# [#norm:vector_ls_EMUL_rsv]#If the EMUL would be out of range (EMUL>8 or
-EMUL<1/8), the instruction encoding is reserved.#  [#norm:vector_ls_EMUL_offgroup_rsv]#The vector register
+(EEW/SEW)*LMUL.# [#norm:vector_ls_emul_rsv]#If the EMUL would be out of range (EMUL>8 or
+EMUL<1/8), the instruction encoding is reserved.#  [#norm:vector_ls_emul_offgroup_rsv]#The vector register
 groups must have legal register specifiers for the selected EMUL,
 otherwise the instruction encoding is reserved.#
 
-[[norm:vector_ls_indexed_EEW_EMUL]]
+[[norm:vector_ls_indexed_eew_emul]]
 Vector unit-stride and constant-stride use the EEW/EMUL encoded in the
 instruction for the data values, while vector indexed loads and stores
 use the EEW/EMUL encoded in the instruction for the index values and
@@ -1677,7 +1677,7 @@ Negative and zero strides are supported.
 Element accesses within a constant-stride instruction are unordered with
 respect to each other.
 
-[[norm:VECTOR_LS_CONSTANT_STRIDE_x0_OPT]]
+[[norm:vector_ls_constant_stride_x0_opt]]
 When `rs2`=`x0`, then an implementation is allowed, but not required,
 to perform fewer memory operations than the number of active elements,
 and may perform different numbers of memory operations across
@@ -1813,7 +1813,7 @@ arrays between memory and registers, and can support operations on
 "array-of-structures" datatypes by unpacking each field in a structure
 into a separate vector register.
 
-[[norm:NFIELDS]]
+[[norm:nfields]]
 The three-bit `nf` field in the vector instruction encoding is an
 unsigned integer that contains one less than the number of fields per
 segment, _NFIELDS_.
@@ -1834,7 +1834,7 @@ segment, _NFIELDS_.
 | 1 | 1 | 1 | 8
 |===
 
-[[norm:EMUL_NFIELDS_rsv]]
+[[norm:emul_nfields_rsv]]
 The EMUL setting must be such that EMUL * NFIELDS {le} 8, otherwise
 the instruction encoding is reserved.
 
@@ -1844,7 +1844,7 @@ instruction.  This constraint makes this total no larger than 1/4 of
 the architectural register file, and the same as for regular
 operations with EMUL=8.
 
-[[norm:NFIELDS_op]]
+[[norm:nfields_op]]
 Each field will be held in successively numbered vector register
 groups.  When EMUL>1, each field will occupy a vector register group
 held in multiple successively numbered vector registers, and the
@@ -1871,7 +1871,7 @@ For segment loads and stores, the individual memory accesses used to
 access fields within each segment are unordered with respect to each
 other even for ordered indexed segment loads and stores.
 
-[#norm:vector_ls_seg_vstart_dep]#The `vstart` value is in units of whole segments.#  [#norm:VECTOR_LS_SEG_PARTIAL_ACCESS]#If a trap occurs during
+[#norm:vector_ls_seg_vstart_dep]#The `vstart` value is in units of whole segments.#  [#norm:vector_ls_seg_partial_access]#If a trap occurs during
 access to a segment, it is implementation-defined whether a subset
 of the faulting segment's accesses are performed before the trap is taken.#
 
@@ -1935,11 +1935,11 @@ For fault-only-first segment loads, if an exception is detected partway
 through accessing the zeroth segment, the trap is taken.
 If an exception is detected partway through accessing a subsequent segment,
 `vl` is reduced to the index of that segment.
-[[norm:VECTOR_FF_SEG_PARTIAL_ACCESS]]
+[[norm:vector_ff_seg_partial_access]]
 In both cases, it is implementation-defined whether a subset of the segment is
 loaded.
 
-[[norm:VECTOR_LS_SEG_FF_OVERLOAD]]
+[[norm:vector_ls_seg_ff_overload]]
 These instructions may overwrite destination vector register group
 elements past the point at which a trap is reported or past the point
 at which vector length is trimmed.
@@ -1979,11 +1979,11 @@ in memory.
 
 [#norm:vector_ls_seg_indexed_op]#Vector indexed segment loads and stores move contiguous segments where each segment is located at an address given by adding the scalar base address in the `rs1` field to byte offsets in vector register `vs2`.# Both ordered and unordered forms are provided, where the ordered forms access segments in element order. [#norm:vector_ls_seg_indexed_unordered]#However, even for the ordered form, accesses to the fields within an individual segment are not ordered with respect to each other.#
 
-[[norm:vector_ls_seg_indexed_EEW_EMUL_op]]
+[[norm:vector_ls_seg_indexed_eew_emul_op]]
 The data vector register group has EEW=SEW, EMUL=LMUL, while the index
 vector register group has EEW encoded in the instruction with
 EMUL=(EEW/SEW)*LMUL.
-[[norm:vector_ls_seg_indexed_EMUL_NFIELDS_val]]
+[[norm:vector_ls_seg_indexed_emul_nfields_val]]
 The EMUL * NFIELDS {le} 8 constraint applies to the data vector register group.
 
 ----
@@ -2070,7 +2070,7 @@ function calls where values are passed in vector registers, interrupt
 handlers, and OS context switches.  Software can determine the number
 of bytes transferred by reading the `vlenb` register.
 
-[[norm:vector_ls_seg_wholereg_EEW]]
+[[norm:vector_ls_seg_wholereg_eew]]
 The load instructions have an EEW encoded in the `mew` and `width`
 fields following the pattern of regular unit-stride loads.
 
@@ -2203,14 +2203,14 @@ as scalar misaligned memory accesses.
 Vector memory instructions appear to execute in program order on the
 local hart.
 
-[#norm:vector_ls_RVWMO]#Vector memory instructions follow RVWMO at the instruction level.#
-[#norm:vector_ls_RVTSO]#If the Ztso extension is implemented, vector memory instructions additionally follow RVTSO at the instruction level.#
+[#norm:vector_ls_rvwmo]#Vector memory instructions follow RVWMO at the instruction level.#
+[#norm:vector_ls_rvtso]#If the Ztso extension is implemented, vector memory instructions additionally follow RVTSO at the instruction level.#
 
 [[norm:vector_ls_indexed-ordered_ordered]]
 Except for vector indexed-ordered loads and stores, element operations
 are unordered within the instruction.
 
-[[norm:vector_ls_indexed-ordered_RVWMO]]
+[[norm:vector_ls_indexed-ordered_rvwmo]]
 Vector indexed-ordered loads and stores read and write elements
 from/to memory in element order respectively,
 obeying RVWMO at the element level.


### PR DESCRIPTION
## Summary
- convert all normative rule tags in the vector standard extension spec to lowercase
- keep the matching tag references in the YAML normative rule definitions synchronized in lowercase

## Testing
- Not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68dd92c73ae0833281f3c55ee8584fe2